### PR TITLE
Missing citations in main feature and GARNET network model sections

### DIFF
--- a/changes/garnet-network-model.tex
+++ b/changes/garnet-network-model.tex
@@ -7,10 +7,10 @@ It provides the ability to create arbitrary topologies – thereby constructing 
 There are two major variants of network models available within the ruby memory system today: simple and garnet.
 The Simple network models the routers, links, and the latencies involved with minimal detailing.
 This is great for simulations that can sacrifice interconnect detailing for faster simulation.
-The Garnet model adds detailed router microarchitecture with cycle-level buffering, resource-contention and flow control mechanisms~\cite{}(N. Agarwal, T. Krishna, L. Peh and N. K. Jha, GARNET: A detailed on-chip network model inside a full-system simulator, 2009 IEEE International Symposium on Performance Analysis of Systems and Software, Boston, MA, 2009, pp. 33-42, doi: 10.1109/ISPASS.2009.4919636.).
+The Garnet model adds detailed router microarchitecture with cycle-level buffering, resource-contention and flow control mechanisms~\cite{garnet-2}.
 This model is suitable for studies that focus on interconnection units and data flow patterns.
 
 gem5 currently implements an upgraded Garnet 2.0 model which provides custom routing algorithms, routers/links that support heterogenous latencies, and standalone network simulation support.
 These features allow detailed studies of on-chip networks as well as support for highly flexible topologies.
 Garnet is moving to version 3.0 with the release of HeteroGarnet which is underway.
-HeteroGarnet revamps Garnet to support the modern heterogenous systems such as 2.5D integration systems, MCM based architectures, and futuristic interconnect designs such as optical networks~\cite{}( S. Bharadwaj, J. Yin, B. Beckmann, T. Krishna, Kite: A Family of Heterogeneous Interposer Topologies Enabled via Accurate Interconnect Modeling, 2020 57th ACM/IEEE Design Automation Conference (DAC), San Francisco, CA, USA, 2020.).
+HeteroGarnet revamps Garnet to support the modern heterogenous systems such as 2.5D integration systems, MCM based architectures, and futuristic interconnect designs such as optical networks~\cite{kite}.

--- a/intro.tex
+++ b/intro.tex
@@ -132,7 +132,7 @@ Both Ruby and the classic caches can be used with any CPU model, any ISA, and an
 
 The gem5 simulator also includes an event-driven DRAM model.
 This DRAM model is easily configurable with the timing parameters for a variety of different DRAM controllers including DDR3, DDR4, GDDR, HBM, HMC, LPDDR4, LPDDR5, and others.
-Although this is not a cycle-accurate DRAM model like DRAMSim~\cite{} or Ramulator~\cite{}, it is nearly as accurate while providing more flexibility and higher performance~\cite{hansson-ispass-paper}
+Although this is not a cycle-accurate DRAM model like DRAMSim~\cite{dramsim, dramsim2, dramsim3} or Ramulator~\cite{ramulator}, it is nearly as accurate while providing more flexibility and higher performance~\cite{hansson-ispass-paper}
 
 In addition to CPU models, gem5 also includes a cycle-level compute-based GPU~\cite{}.
 This GPU model does not support graphics applications, but supports many compute applications based on OpenCL.
@@ -140,11 +140,11 @@ This GPU model does not support graphics applications, but supports many compute
 
 An important component to full system simulation is supporting I/O and other devices.
 gem5 supports many system-agnostic devices such as disk controllers, PCI components, ethernet controllers, etc. and system-specific devices such as the Arm GIC and SMMU and x86 PC devices.
-Additionally, gem5 contains support for a ``fake'' graphics GPU to enable simulating applications that depend on graphics APIs.
+Additionally, gem5 contains support for a ``fake'' graphics GPU to enable simulating applications that depend on graphics APIs~\cite{nomali}.
 
 Finally, gem5 has been integrated with other computer architecture simulator systems to enable users with models in other simulator systems to use gem5's features.
-For instance, gem5 has been integrated with the System Simulation Toolkit (SST)~\cite{} which uses gem5's detailed CPU models in conjunction with SST's multi-node modeling capabilities.
-The IEEE standard SystemC API~\cite{} has also been integrated with gem5 to enable users with SystemC models to use them as gem5 components.
+For instance, gem5 has been integrated with the System Simulation Toolkit (SST)~\cite{sst-gem5} which uses gem5's detailed CPU models in conjunction with SST's multi-node modeling capabilities.
+The IEEE standard SystemC API~\cite{menard2017-system-systemc} has also been integrated with gem5 to enable users with SystemC models to use them as gem5 components.
 
 Although there are many computer architecture simulators, and many of these are open source with features that overlap with gem5, gem5 is a unique simulation infrastructure.
 \begin{itemize}

--- a/references.bib
+++ b/references.bib
@@ -288,3 +288,12 @@ series = {ISCA ’10}
 	number={},
 	pages={255-262},
 }
+
+@inproceedings{kite,
+	author={S. {Bharadwaj} and J. {Yin} and B. {Beckmann} and T. {Krishna}},
+	booktitle={2020 57th ACM/IEEE Design Automation Conference (DAC)},
+	title={Kite: A Family of Heterogeneous Interposer Topologies Enabled via Accurate Interconnect Modeling},
+	year={2020},
+	volume={},
+	number={},
+}

--- a/references.bib
+++ b/references.bib
@@ -188,3 +188,103 @@ series = {ISCA ’10}
   Owner                    = {MJ},
   Timestamp                = {2017-06-29}
 }
+
+@INPROCEEDINGS{full-speed-ahead,
+	author={A. {Sandberg} and N. {Nikoleris} and T. E. {Carlson} and E. {Hagersten} and S. {Kaxiras} and D. {Black-Schaffer}},
+	booktitle={2015 IEEE International Symposium on Workload Characterization},
+	title={Full Speed Ahead: Detailed Architectural Simulation at Near-Native Speed},
+	year={2015},
+	volume={},
+	number={},
+	pages={183-192},
+}
+
+@inproceedings{garnet-2,
+	title={GARNET: A detailed on-chip network model inside a full-system simulator},
+	author={Agarwal, Niket and Krishna, Tushar and Peh, Li-Shiuan and Jha, Niraj K},
+	booktitle={Performance Analysis of Systems and Software, 2009. ISPASS 2009. IEEE International Symposium on},
+	pages={33--42},
+	year={2009},
+	organization={IEEE}
+}
+
+@article{ramulator,
+	author = {Kim, Yoongu and Yang, Weikun and Mutlu, Onur},
+	title = {Ramulator: A Fast and Extensible DRAM Simulator},
+	year = {2016},
+	issue_date = {January 2016},
+	publisher = {IEEE Computer Society},
+	address = {USA},
+	volume = {15},
+	number = {1},
+	issn = {1556-6056},
+	url = {https://doi.org/10.1109/LCA.2015.2414456},
+	doi = {10.1109/LCA.2015.2414456},
+	journal = {IEEE Comput. Archit. Lett.},
+	month = jan,
+	pages = {45–49},
+	numpages = {5}
+}
+
+@article{dramsim,
+	author = {Wang, David and Ganesh, Brinda and Tuaycharoen, Nuengwong and Baynes, Kathleen and Jaleel, Aamer and Jacob, Bruce},
+	title = {DRAMsim: A Memory System Simulator},
+	year = {2005},
+	issue_date = {November 2005},
+	publisher = {Association for Computing Machinery},
+	address = {New York, NY, USA},
+	volume = {33},
+	number = {4},
+	issn = {0163-5964},
+	url = {https://doi.org/10.1145/1105734.1105748},
+	doi = {10.1145/1105734.1105748},
+	journal = {SIGARCH Comput. Archit. News},
+	month = nov,
+	pages = {100–107},
+	numpages = {8}
+}
+
+@article{dramsim2,
+	author={P. {Rosenfeld} and E. {Cooper-Balis} and B. {Jacob}},
+	journal={IEEE Computer Architecture Letters},
+	title={DRAMSim2: A Cycle Accurate Memory System Simulator},
+	year={2011},
+	volume={10},
+	number={1},
+	pages={16-19},
+}
+
+@article{dramsim3,
+	author={S. {Li} and Z. {Yang} and D. {Reddy} and A. {Srivastava} and B. {Jacob}},
+	journal={IEEE Computer Architecture Letters},
+	title={DRAMsim3: a Cycle-accurate, Thermal-Capable DRAM Simulator},
+	year={2020},
+	volume={},
+	number={},
+	pages={1-1},
+}
+
+@inproceedings{sst-gem5,
+	author = {Hsieh, Mingyu and Pedretti, Kevin and Meng, Jie and Coskun, Ayse and Levenhagen, Michael and Rodrigues, Arun},
+	title = {SST + Gem5 = a Scalable Simulation Infrastructure for High Performance Computing},
+	year = {2012},
+	isbn = {9781450315104},
+	publisher = {ICST (Institute for Computer Sciences, Social-Informatics and Telecommunications Engineering)},
+	address = {Brussels, BEL},
+	booktitle = {Proceedings of the 5th International ICST Conference on Simulation Tools and Techniques},
+	pages = {196–201},
+	numpages = {6},
+	keywords = {architecture, simulation},
+	location = {Desenzano del Garda, Italy},
+	series = {SIMUTOOLS ’12}
+}
+
+@inproceedings{nomali,
+	author={R. {de Jong} and A. {Sandberg}},
+	booktitle={2016 IEEE International Symposium on Performance Analysis of Systems and Software (ISPASS)},
+	title={NoMali: Simulating a realistic graphics driver stack using a stub GPU},
+	year={2016},
+	volume={},
+	number={},
+	pages={255-262},
+}


### PR DESCRIPTION
Add missing citations
- full speed ahead
- garnet network model
- ramulator, dramsim1~3
- nomali
- sst, systemC

Signed-off-by: hanhwi <jang.hanhwi@gmail.com>