### PR TITLE
changes: Replace ARM with Arm

### DIFF
--- a/changes/arm-fastmodel.tex
+++ b/changes/arm-fastmodel.tex
@@ -1,3 +1,3 @@
-\subsection[ARM Fastmodel]{ARM Fastmodel\footnote{By Gabriel Black}}
+\subsection[Arm Fastmodel]{Arm Fastmodel\footnote{By Gabriel Black}}
 
 Haven't heard anything back, yet.

--- a/changes/arm-improvements.tex
+++ b/changes/arm-improvements.tex
@@ -1,6 +1,6 @@
-\subsection[ARM Improvements]{ARM Improvements}
+\subsection[Arm Improvements]{Arm Improvements}
 
-\subsubsection[ARMv8 Support]{ARMv8 Support\footnote{by Giacomo Gabrielli, Javier Setoain, and Giacomo Travaglini}}
+\subsubsection[Armv8 Support]{Armv8 Support\footnote{by Giacomo Gabrielli, Javier Setoain, and Giacomo Travaglini}}
 
 The Armv8-A architecture introduced two different architectural states:
 AArch32, supporting the A32 and T32 instruction sets (backward-compatible with

--- a/changes/ruby-cache-model.tex
+++ b/changes/ruby-cache-model.tex
@@ -29,6 +29,6 @@ Levels 0 and 1 are private to the CPU core, which the second level is shared acr
 
 Haven't heard anything, yet.
 
-\subsubsection[ARM Support and Extensions]{ARM Support in Ruby Coherence Protocols\footnote{by Tiago M{\"u}ck}}
+\subsubsection[Arm Support and Extensions]{Arm Support in Ruby Coherence Protocols\footnote{by Tiago M{\"u}ck}}
 
 Haven't heard anything, yet.

--- a/changes/x86-improvements.tex
+++ b/changes/x86-improvements.tex
@@ -15,4 +15,4 @@ Memory consistency models decide the amount of parallelism available in a memory
 The x86 architecture is based on the Total Store Order (TSO) memory model~\cite{coherenceprimer}.
 We added support for TSO to gem5 for the x86 architecture.
 This meant ensuring that a later load from a thread can bypass earlier loads/stores, but stores from the same thread are always executed in order.
-The out-of-order CPU model in gem5 has been improved to implement both TSO and more relaxed consistency models (e.g., those in the RISC-V~\ref{sec:riscv} and ARM~\ref{sec:arm} architectures).
+The out-of-order CPU model in gem5 has been improved to implement both TSO and more relaxed consistency models (e.g., those in the RISC-V~\ref{sec:riscv} and Arm~\ref{sec:arm} architectures).


### PR DESCRIPTION
As mentioned by the issue:
https://github.com/darchr/gem5-20-paper/issues/33

There are several parts where ARM could be easily changed to Arm, but in
some scenarios it might be confusing since the gem5-ISA is still using
the old capitalized name.

This solution is using:

* Arm -> when mentioning the company or the Arch extensions (Armv8.x)
* ARM -> when mentioning the gem5 implementation of the architecture

Signed-off-by: Giacomo Travaglini <giacomo.travaglini@arm.com>