### PR TITLE
change the position of an abbreviation

### DIFF
--- a/intro.tex
+++ b/intro.tex
@@ -81,8 +81,8 @@ We now have a formal governance structure, we have improved our documentation (s
 To institute a formal governance model, we followed the best practices from other successful open source projects.
 We chose to institute a meritocratic governance model where anyone with an interest in the project can join the community, contribute to the project design and participate in the decision-making process.
 The governance structure also defines the roles and responsibilities of members of the community including users, contributors, and maintainers.
-We also formed a project management committee to help ensure smooth running of the project.
-Importantly, members of the project management committee (PMC) do not have significant authority over other members of the community or of the direction of the project.
+We also formed a project management committee (PMC) to help ensure smooth running of the project.
+Importantly, members of the PMC do not have significant authority over other members of the community or of the direction of the project.
 
 To simplify the contribution process, we have instituted many industry-standard development methodologies including providing a \verb|CONTRIBUTING| document in the gem5 source.
 In the past, gem5 code contributions were managed with a number of esoteric software packages.


### PR DESCRIPTION
Just moving PMC to the place where "project management committee" is used first.