### PR TITLE
Spelling updates

### DIFF
--- a/changes/classic-caches-improvements.tex
+++ b/changes/classic-caches-improvements.tex
@@ -49,6 +49,6 @@ We added a snoop filter to gem5 which is a distributed component that keeps trac
 For example, if the snoop filter sits next to the L3 cache and is accessed before the L3, then, it knows about all lines in the L2 and L1 caches that are connected to that L3 cache.
 
 Using the snoop filter, we can reduce the amount of messages from $O(N^2)$ to $O(N)$ with $N$ concurrent requestors in the system.
-Modelling the snoop filter / directory separately from the cache allows us to use different organizations for the filter and the cache, and distributing area between shared caches vs coherence tracking filters / directories.
+Modeling the snoop filter / directory separately from the cache allows us to use different organizations for the filter and the cache, and distributing area between shared caches vs coherence tracking filters / directories.
 We also model the effect of limited filter capacity through back-invalidations that remove cache entries if the filter becomes full; allowing for more realistic cache performance metrics.
 Finally, the more centralized coherence tracking in the filter allows for more tight checking of correct function of the distributed coherence protocol in the classic memory system.

--- a/changes/flexible-dram-controller.tex
+++ b/changes/flexible-dram-controller.tex
@@ -41,7 +41,7 @@ Quality of Service (QoS) is the ability of a system to provide differential trea
 %     The level of service that a QoS enabled resource will guarantee to its users must therefore be predictable to a certain extent given a specific set of policies and their configurations.
 % \end{enumerate}
 
-We now include a QoS-aware memory controller in gem5, and the definition of basic (example) policies modelling the prioritization algorithm of the memory controller.
+We now include a QoS-aware memory controller in gem5, and the definition of basic (example) policies modeling the prioritization algorithm of the memory controller.
 We include models for a \emph{fixed} priority policy (every requestor in the system has a fixed priority assigned) and the \emph{proportional fair} policy (where the priority of a requestor is dynamically adjusted at runtime based on utilization).
 
 The default timing-based DRAM controller described above has been rewritten to include the QoS changes.

--- a/changes/systemc-integration.tex
+++ b/changes/systemc-integration.tex
@@ -2,7 +2,7 @@
 
 While the open and configurable architecture of gem5 is of particular interest
 in academia, the industry's main tool for virtual prototyping is SystemC
-Transaction Level Modelling (TLM)~\cite{systemc_ieee11}. Many hardware vendors
+Transaction Level Modeling (TLM)~\cite{systemc_ieee11}. Many hardware vendors
 provide SystemC TLM models of their IP and there are tools, such as Synopsys
 Platform Architect\footnote{\url{https://www.synopsys.com/verification/virtual-prototyping/platform-architect.html}},
 that assist in building a virtual system and analyzing it. Also, many research


### PR DESCRIPTION
I tried to standardize the spelling for all words to use American
English in this commit, to keep things consistent.  However,
if we do not want to use American English, then this commit should
be removed.