### PR TITLE
Section 2: Fix broken reference

### DIFF
--- a/intro.tex
+++ b/intro.tex
@@ -40,7 +40,7 @@ It has taken a huge number of people to make gem5 what it is today.
 One of the goals of this paper is to recognize the hard work on this community infrastructure which is often overlooked.
 We have tried to include everyone who has contributed and documented all of the major changes.
 
-\subsection{The past, present, and future of gem5}
+\subsection{The past, present, and future of gem5}\label{sec:current-gem5}
 
 The gem5 simulator was born when the m5 simulator~\cite{BinkertDHLSR06} created at University of Michigan merged with the GEMS simulator~\cite{MartinSBMXAMHW05} from University of Wisconsin.
 These were two academic-oriented simulators, neither of which had an open development community (both simulators had their source available for free\footnote{\url{https://sourceforge.net/projects/m5sim/}}\footnote{https://research.cs.wisc.edu/gems/home.html}, but did not have a community-oriented development process).


### PR DESCRIPTION
I am referencing back to 1.1 although maybe referencing to "The present
of gem5" would be more accurate. If this was meant to be fixed later
with the latter feel free to ignore this one.