### PR TITLE
Fixes in arm-improvements.tex

### DIFF
--- a/changes/arm-improvements.tex
+++ b/changes/arm-improvements.tex
@@ -17,7 +17,7 @@ several smaller iterations introduced by Arm with a yearly cadence, and various
 contributors have implemented some of the main features from those extensions,
 up to Armv8.3-A.
 
-\subsubsection[Support for the Arm Scalable Vector Extension (SVE)]{Support for the Arm Scalable Vector Extension (SVE)\footnote{by Giacomo Gabrielli, Javier Setoain, and Giacomo Travaglini}}
+\subsubsection[Support for the Arm Scalable Vector Extension (SVE)]{Support for the Arm Scalable Vector Extension (SVE)\footnote{by Gabor Dozsa, Giacomo Gabrielli, Rekai Gonzalez-Alberquilla, Nathanael Premillieu, and Javier Setoain}}
 
 In 2016, Arm introduced their Scalable Vector Extension (SVE)~\cite{ArmARM}, a
 novel approach to vector instruction sets. Instead of having fixed-size vector

--- a/changes/arm-improvements.tex
+++ b/changes/arm-improvements.tex
@@ -1,7 +1,7 @@
 \subsection[Arm Improvements]{Arm Improvements}
 \label{sec:arm}
 
-\subsubsection[Armv8 Support]{Armv8 Support\footnote{by Giacomo Gabrielli, Javier Setoain, and Giacomo Travaglini}}
+\subsubsection[Armv8 Support]{Armv8 Support\footnote{by Giacomo Gabrielli, Andreas Sandberg, and Giacomo Travaglini}}
 
 The Armv8-A architecture introduced two different architectural states:
 AArch32, supporting the A32 and T32 instruction sets (backward-compatible with

--- a/changes/arm-improvements.tex
+++ b/changes/arm-improvements.tex
@@ -54,4 +54,4 @@ These are loosely based on a Versatile\texttrademark Express RS1 platform with a
 
 Towards unifying Arm's platform landscape, we now provide a \verb|VExpress_GEM5_Foundation| platform as part of gem5's \verb|VExpress_GEM5_Base| family.
 This is based on and compatible with FVP Foundation, meaning all Foundation software may run unmodified in gem5, including but not limited to TF-A.
-This allows for simulating boot flows based on UEFI implementations (U-boot, EDK II), and brings us a step closer to Windows support in gem5.
+This allows for simulating boot flows based on UEFI implementations (U-boot, EDK II), and brings us a step closer to support for all UEFI compatible Operating Systems in gem5.

--- a/changes/arm-improvements.tex
+++ b/changes/arm-improvements.tex
@@ -1,7 +1,7 @@
 \subsection[Arm Improvements]{Arm Improvements}
 \label{sec:arm}
 
-\subsubsection[Armv8 Support]{Armv8 Support\footnote{by Giacomo Gabrielli, Andreas Sandberg, and Giacomo Travaglini}}
+\subsubsection[Armv8-A Support]{Armv8-A Support\footnote{by Giacomo Gabrielli, Andreas Sandberg, and Giacomo Travaglini}}
 
 The Armv8-A architecture introduced two different architectural states:
 AArch32, supporting the A32 and T32 instruction sets (backward-compatible with


### PR DESCRIPTION
This PR is addressing the following issues:

* Replacing Windows support with a more generic UEFI compatible OS
* Fixing autorship for SVE
* Fixing autorhip for Armv8
* Replacing Armv8 with Armv8-A (to distinguish it from Armv8-M, which is not supported on gem5)